### PR TITLE
Update RXOR to utilize full key length

### DIFF
--- a/Runtime/Runtime.cs
+++ b/Runtime/Runtime.cs
@@ -31,25 +31,25 @@ public static unsafe class Runtime
             // We need to add 8 to the pointer because 4 bytes are reserved for the length and another 4 bytes for the XOR key
             cpblk(ptr, data + 8, (uint) buffer.Length);
         }
-
+        
         int n = buffer.Length - 1;
+        byte* key = stackalloc byte[4];
+
+        // Extract bytes of the key and copy them to the allocated stack memory
+        for (int j = 0; j < 4; j++)
+        {
+            key[j] = (byte)(*(int*)(data + 4) >> (8 * j));
+        }
+
         for (int i = 0; i < n; i++, n--)
         {
             buffer[i] ^= buffer[n];
-            for (int j = 0; j < 4; j++)
-            {
-                buffer[n] ^= (byte)(buffer[i] ^ (byte)(*(int*)(data + 4) >> (8*j)) & 0xFF);
-            }
+            buffer[n] ^= (byte)(buffer[i] ^ key[i % 4]);
             buffer[i] ^= buffer[n];
         }
-        
+
         if (buffer.Length % 2 != 0)
-        {
-            for (int j = 0; j < 4; j++)
-            {
-                buffer[buffer.Length >> 1] ^= (byte)((*(int*)(data + 4) >> (8*j)) & 0xFF); // x >> 1 == x / 2
-            }
-        }
+            buffer[buffer.Length >> 1] ^= key[0];
 
 
         // Return the decrypted string as UTF8

--- a/Runtime/Runtime.cs
+++ b/Runtime/Runtime.cs
@@ -36,11 +36,20 @@ public static unsafe class Runtime
         for (int i = 0; i < n; i++, n--)
         {
             buffer[i] ^= buffer[n];
-            buffer[n] ^= (byte)(buffer[i] ^ *(int*) (data + 4));
+            for (int j = 0; j < 4; j++)
+            {
+                buffer[n] ^= (byte)(buffer[i] ^ (byte)(*(int*)(data + 4) >> (8*j)) & 0xFF);
+            }
             buffer[i] ^= buffer[n];
         }
+        
         if (buffer.Length % 2 != 0)
-            buffer[buffer.Length >> 1] ^= (byte)*(int*) (data + 4); // x >> 1 == x / 2
+        {
+            for (int j = 0; j < 4; j++)
+            {
+                buffer[buffer.Length >> 1] ^= (byte)((*(int*)(data + 4) >> (8*j)) & 0xFF); // x >> 1 == x / 2
+            }
+        }
 
 
         // Return the decrypted string as UTF8

--- a/XorStrings/EncryptionService.cs
+++ b/XorStrings/EncryptionService.cs
@@ -52,24 +52,16 @@ public class EncryptionService
 
         // RXOR Cipher: reverse array order and decrypt byte by byte using single XOR
         int n = data.Length - 1;
+        byte[] key_data = BitConverter.GetBytes(key);
         for (int i = 0; i < n; i++, n--)
         {
             data[i] ^= data[n];
-            // Encrypt data using every byte of the key
-            for (int j = 0; j < 4; j++)
-            {
-                data[n] ^= (byte)(data[i] ^ (byte)(key >> (8*j)) & 0xFF);
-            }
+            data[n] ^= (byte)(data[i] ^ key_data[i % key_data.Length]);
             data[i] ^= data[n];
         }
 
-        if (data.Length % 2 == 0)
-            return data;
-
-        for (int j = 0; j < 4; j++)
-        {
-            data[data.Length >> 1] ^= (byte)((key >> (8 * j)) & 0xFF); // x >> 1 == x / 2
-        }
+        if (data.Length % 2 != 0)
+            data[data.Length >> 1] ^= (byte)key; // x >> 1 == x / 2
 
         return data;
     }

--- a/XorStrings/EncryptionService.cs
+++ b/XorStrings/EncryptionService.cs
@@ -55,12 +55,21 @@ public class EncryptionService
         for (int i = 0; i < n; i++, n--)
         {
             data[i] ^= data[n];
-            data[n] ^= (byte) (data[i] ^ key);
+            // Encrypt data using every byte of the key
+            for (int j = 0; j < 4; j++)
+            {
+                data[n] ^= (byte)(data[i] ^ (byte)(key >> (8*j)) & 0xFF);
+            }
             data[i] ^= data[n];
         }
 
-        if (data.Length % 2 != 0)
-            data[data.Length >> 1] ^= (byte) key; // x >> 1 == x / 2
+        if (data.Length % 2 == 0)
+            return data;
+
+        for (int j = 0; j < 4; j++)
+        {
+            data[data.Length >> 1] ^= (byte)((key >> (8 * j)) & 0xFF); // x >> 1 == x / 2
+        }
 
         return data;
     }


### PR DESCRIPTION
In its current implementation the RXOR cipher only uses the first byte of the four byte integer key. 

```
int n = buffer.Length - 1;
byte* key = stackalloc byte[4]
for (int j = 0; j < 4; j++)
{
    key[j] = (byte)(*(int*)(data + 4) >> (8 * j));

for (int i = 0; i < n; i++, n--)
{
    buffer[i] ^= buffer[n];
    buffer[n] ^= (byte)(buffer[i] ^ key[i % 4]);
    buffer[i] ^= buffer[n];

if (buffer.Length % 2 != 0)
    buffer[buffer.Length >> 1] ^= key[0];
```

The new implementation uses a loop to extract each byte of the key and store them in stack allocated memory, then makes use of the standard XOR cipher to iterate over the key bytes. For the single byte that gets missed by the initial reverse loop I use the first byte of the key for simplicity.